### PR TITLE
Return a boolean from Metrics.start()

### DIFF
--- a/Bukkit/Metrics.java
+++ b/Bukkit/Metrics.java
@@ -187,11 +187,13 @@ public class Metrics {
      * Start measuring statistics. This will immediately create an async repeating task as the plugin and send
      * the initial data to the metrics backend, and then after that it will post in increments of
      * PING_INTERVAL * 1200 ticks.
+     *
+     * @return True if statistics measuring is now running, otherwise false.
      */
-    public void start() {
+    public boolean start() {
         // Did we opt out?
         if (configuration.getBoolean("opt-out", false)) {
-            return;
+            return false;
         }
 
         // Begin hitting the server with glorious data
@@ -213,6 +215,8 @@ public class Metrics {
                 }
             }
         }, 0, PING_INTERVAL * 1200);
+
+        return true;
     }
 
     /**

--- a/Bukkit/MetricsLite.java
+++ b/Bukkit/MetricsLite.java
@@ -86,11 +86,13 @@ public class MetricsLite {
      * Start measuring statistics. This will immediately create an async repeating task as the plugin and send
      * the initial data to the metrics backend, and then after that it will post in increments of
      * PING_INTERVAL * 1200 ticks.
+     *
+     * @return True if statistics measuring is now running, otherwise false.
      */
-    public void start() {
+    public boolean start() {
         // Did we opt out?
         if (configuration.getBoolean("opt-out", false)) {
-            return;
+            return false;
         }
 
         // Begin hitting the server with glorious data
@@ -112,6 +114,8 @@ public class MetricsLite {
                 }
             }
         }, 0, PING_INTERVAL * 1200);
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Using this in my code simply for logging purposes (don't show a message saying we're sending data if they have disabled in the metrics config).

Alternatively, a separate public method to return configuration.getBoolean("opt-out", false) might be preferred.
