### PR TITLE
Notify Plotters when the server owner decides to opt-out during runtime.

### DIFF
--- a/Bukkit/Metrics.java
+++ b/Bukkit/Metrics.java
@@ -234,9 +234,7 @@ public class Metrics {
                                 taskId = -1;
                                 // Tell all plotters to stop gathering information.
                                 for (Graph graph : graphs){
-                                    for (Plotter plotter : graph.getPlotters()){
-                                        plotter.onOptOut();
-                                    }
+                                    graph.onOptOut();
                                 }
                             }
                         }
@@ -529,6 +527,11 @@ public class Metrics {
             return graph.name.equals(name);
         }
 
+        /**
+         * Called when the server owner decides to opt-out of Metrics while the server is running.
+         */
+        protected void onOptOut(){}
+
     }
 
     /**
@@ -593,11 +596,6 @@ public class Metrics {
             final Plotter plotter = (Plotter) object;
             return plotter.name.equals(name) && plotter.getValue() == getValue();
         }
-
-        /**
-         * Called when the server owner decides to opt-out of Metrics while the server is running.
-         */
-        protected abstract void onOptOut();
 
     }
 


### PR DESCRIPTION
Implements a call to an abstract method of all Plotters of all Graphs, if isOptOut() returns false during the execution of the run() method.
