### PR TITLE
Fix improper graph subtitle

### DIFF
--- a/src/includes/Graph.class.php
+++ b/src/includes/Graph.class.php
@@ -248,7 +248,7 @@ class Graph
         if ($this->plugin != null)
         {
             $chart->subtitle = array(
-                'text' => 'for ' . htmlentities($this->displayName) . ' via http://mcstats.org'
+                'text' => 'for ' . htmlentities($this->plugin->getName()) . ' via http://mcstats.org'
             );
         } else
         {


### PR DESCRIPTION
Fix plugin name not displaying for graph subtitles. The current website shows: http://screensnapr.com/v/4bKOon.jpg
