### PR TITLE
Fix BungeeCord support to use BungeeCord's own GUID

### DIFF
--- a/mods/bungee/metrics-lite/src/main/java/org/mcstats/MetricsLite.java
+++ b/mods/bungee/metrics-lite/src/main/java/org/mcstats/MetricsLite.java
@@ -88,7 +88,7 @@ public class MetricsLite {
     /**
      * Unique server id
      */
-    private final String guid;
+    private String guid;
 
     /**
      * Debug mode
@@ -125,7 +125,6 @@ public class MetricsLite {
 
             configurationFile.createNewFile(); // config file
             properties.put("opt-out", "false");
-            properties.put("guid", UUID.randomUUID().toString());
             properties.put("debug", "false");
             properties.store(new FileOutputStream(configurationFile), "http://mcstats.org");
         } else {
@@ -133,7 +132,7 @@ public class MetricsLite {
         }
 
         // Load the guid then
-        guid = properties.getProperty("guid");
+        guid = ProxyServer.getInstance().getConfigurationAdapter().getString("stats", UUID.randomUUID().toString());
         debug = Boolean.parseBoolean(properties.getProperty("debug"));
     }
 
@@ -221,7 +220,8 @@ public class MetricsLite {
                 return true;
             }
             
-            return Boolean.parseBoolean(properties.getProperty("opt-out"));
+            guid = ProxyServer.getInstance().getConfigurationAdapter().getString("stats", UUID.randomUUID().toString());
+            return guid.equals("null") || Boolean.parseBoolean(properties.getProperty("opt-out"));
         }
     }
 

--- a/mods/bungee/metrics/src/main/java/org/mcstats/Metrics.java
+++ b/mods/bungee/metrics/src/main/java/org/mcstats/Metrics.java
@@ -107,7 +107,7 @@ public class Metrics {
     /**
      * Unique server id
      */
-    private final String guid;
+    private String guid;
     /**
      * Debug mode
      */
@@ -141,7 +141,6 @@ public class Metrics {
 
             configurationFile.createNewFile(); // config file
             properties.put("opt-out", "false");
-            properties.put("guid", UUID.randomUUID().toString());
             properties.put("debug", "false");
             properties.store(new FileOutputStream(configurationFile), "http://mcstats.org");
         } else {
@@ -149,7 +148,7 @@ public class Metrics {
         }
 
         // Load the guid then
-        guid = properties.getProperty("guid");
+        guid = ProxyServer.getInstance().getConfigurationAdapter().getString("stats", UUID.randomUUID().toString());
         debug = Boolean.parseBoolean(properties.getProperty("debug"));
     }
 
@@ -294,7 +293,8 @@ public class Metrics {
                 return true;
             }
             
-            return Boolean.parseBoolean(properties.getProperty("opt-out"));
+            guid = ProxyServer.getInstance().getConfigurationAdapter().getString("stats", UUID.randomUUID().toString());
+            return guid.equals("null") || Boolean.parseBoolean(properties.getProperty("opt-out"));
         }
     }
 


### PR DESCRIPTION
Hey, 
So after talking to md_5, creator of bungeecord, I discovered BungeeCord already "implements" metrics to keep track of how many servers run bungee, and as such has it's own GUID. This PR changes the GUID to use bungeecord's.

Also, the way to opt-out of metrics in bungeecord is to set the GUID to "null" in the config. As such, I added a check in isOptOut to see if the GUID was changed to null.
