### PR TITLE
Adjust dependency scopes to be more appropriate

### DIFF
--- a/mods/bukkit/metrics-lite/pom.xml
+++ b/mods/bukkit/metrics-lite/pom.xml
@@ -26,7 +26,7 @@
             <artifactId>bukkit</artifactId>
             <version>1.4.5-R0.3-SNAPSHOT</version>
             <type>jar</type>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/mods/bukkit/metrics/pom.xml
+++ b/mods/bukkit/metrics/pom.xml
@@ -26,7 +26,7 @@
             <artifactId>bukkit</artifactId>
             <version>1.4.5-R0.3-SNAPSHOT</version>
             <type>jar</type>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/mods/bungee/metrics-lite/pom.xml
+++ b/mods/bungee/metrics-lite/pom.xml
@@ -26,7 +26,7 @@
             <artifactId>bungeecord-api</artifactId>
             <version>1.4.7-SNAPSHOT</version>
             <type>jar</type>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/mods/bungee/metrics/pom.xml
+++ b/mods/bungee/metrics/pom.xml
@@ -26,7 +26,7 @@
             <artifactId>bungeecord-api</artifactId>
             <version>1.4.7-SNAPSHOT</version>
             <type>jar</type>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/mods/canary/metrics-lite/pom.xml
+++ b/mods/canary/metrics-lite/pom.xml
@@ -25,7 +25,7 @@
             <groupId>net.canarymod</groupId>
             <artifactId>canarymod</artifactId>
             <version>5.5.11-SNAPSHOT</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/mods/canary/metrics/pom.xml
+++ b/mods/canary/metrics/pom.xml
@@ -25,7 +25,7 @@
             <groupId>net.canarymod</groupId>
             <artifactId>canarymod</artifactId>
             <version>5.5.11-SNAPSHOT</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
From the maven documentation:
>**provided**
>This is much like compile, but indicates you expect the JDK or a container to provide the dependency at runtime.

The container being the appropriate server mod, this fixes an annoying issue with maven transitive dependencies that I've been facing due to a dependency on metrics too. I only changed it for the ones I'm familiar with, no clue how the others work so I'll just play the safe card there