### PR TITLE
updatet to SpongeApi 2.1

### DIFF
--- a/mods/sponge/metrics-lite/pom.xml
+++ b/mods/sponge/metrics-lite/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>2.1-20150715.230258-127</version>
+            <version>2.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/mods/sponge/metrics-lite/pom.xml
+++ b/mods/sponge/metrics-lite/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>2.0</version>
+            <version>2.1-20150715.230258-127</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/mods/sponge/metrics-lite/src/main/java/org/mcstats/MetricsLite.java
+++ b/mods/sponge/metrics-lite/src/main/java/org/mcstats/MetricsLite.java
@@ -178,7 +178,7 @@ public class MetricsLite {
             }
 
             // Begin hitting the server with glorious data
-            task = game.getAsyncScheduler().runRepeatingTask(plugin, new Runnable() {
+            task = game.getScheduler().createTaskBuilder().async().execute(new Runnable() {
                 private boolean firstPost = true;
 
                 public void run() {
@@ -206,7 +206,7 @@ public class MetricsLite {
                         }
                     }
                 }
-            }, TimeUnit.MINUTES, PING_INTERVAL).orNull();
+            }).interval(PING_INTERVAL, TimeUnit.MINUTES).submit(plugin);
 
             return true;
         }
@@ -289,9 +289,7 @@ public class MetricsLite {
         String pluginName = plugin.getName();
         boolean onlineMode = game.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = plugin.getVersion();
-        // TODO no visible way to get MC version at the moment
-        // TODO added by game.getPlatform().getMinecraftVersion() -- impl in 2.1
-        String serverVersion = String.format("%s %s", "Sponge", game.getImplementationVersion());
+        String serverVersion = String.format("%s %s", "Sponge", game.getPlatform().getMinecraftVersion());
         int playersOnline = game.getServer().getOnlinePlayers().size();
 
         // END server software specific section -- all code below does not use any code outside of this class / Java

--- a/mods/sponge/metrics/pom.xml
+++ b/mods/sponge/metrics/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>2.1-20150715.230258-127</version>
+            <version>2.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/mods/sponge/metrics/pom.xml
+++ b/mods/sponge/metrics/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>2.0</version>
+            <version>2.1-20150715.230258-127</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/mods/sponge/metrics/src/main/java/org/mcstats/Metrics.java
+++ b/mods/sponge/metrics/src/main/java/org/mcstats/Metrics.java
@@ -228,8 +228,6 @@ public class Metrics {
 
                 public void run() {
                     try {
-                        System.out.println("[Metrics] " + "exexuted");
-
                         // This has to be synchronized or it can collide with the disable method.
                         synchronized (optOutLock) {
                             // Disable Task, if it is running and the server owner decided to opt-out

--- a/mods/sponge/metrics/src/main/java/org/mcstats/Metrics.java
+++ b/mods/sponge/metrics/src/main/java/org/mcstats/Metrics.java
@@ -223,11 +223,13 @@ public class Metrics {
             }
 
             // Begin hitting the server with glorious data
-            task = game.getAsyncScheduler().runRepeatingTask(plugin, new Runnable() {
+            task = game.getScheduler().createTaskBuilder().async().execute(new Runnable() {
                 private boolean firstPost = true;
 
                 public void run() {
                     try {
+                        System.out.println("[Metrics] " + "exexuted");
+
                         // This has to be synchronized or it can collide with the disable method.
                         synchronized (optOutLock) {
                             // Disable Task, if it is running and the server owner decided to opt-out
@@ -255,7 +257,7 @@ public class Metrics {
                         }
                     }
                 }
-            }, TimeUnit.MINUTES, PING_INTERVAL).orNull();
+            }).interval(PING_INTERVAL, TimeUnit.MINUTES).submit(plugin);
 
             return true;
         }
@@ -337,9 +339,7 @@ public class Metrics {
         String pluginName = plugin.getName();
         boolean onlineMode = game.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = plugin.getVersion();
-        // TODO no visible way to get MC version at the moment
-        // TODO added by game.getPlatform().getMinecraftVersion() -- impl in 2.1
-        String serverVersion = String.format("%s %s", "Sponge", game.getImplementationVersion());
+        String serverVersion = String.format("%s %s", "Sponge", game.getPlatform().getMinecraftVersion());
         int playersOnline = game.getServer().getOnlinePlayers().size();
 
         // END server software specific section -- all code below does not use any code outside of this class / Java


### PR DESCRIPTION
Due to the renaming of getTaskBuilder() to createTaskBuilder() its not longer possible to use the current version of plugin-metrics with the newest SpongeApi version, so I have updated it to the current version of the SpongeApi.